### PR TITLE
feat: add hero background with gradient overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,11 @@
     <div class="container">
       <!-- HERO -->
       <section id="hero">
+        <img
+          src="https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1600&q=80"
+          alt="Fondo hero"
+          class="hero-bg"
+        />
         <h1>Soy tres versiones del mismo eco.</h1>
         <p class="subtitulo">
           <em>“El verso que no se borra”</em><br /><span

--- a/style.css
+++ b/style.css
@@ -21,6 +21,7 @@ body {
 
 /* Hero */
 #hero {
+  position: relative;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -28,6 +29,32 @@ body {
   align-items: center;
   padding: 2rem;
   text-align: center;
+  overflow: hidden;
+}
+
+#hero img.hero-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -2;
+}
+
+#hero::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.4),
+    rgba(0, 0, 0, 0.7)
+  );
+  z-index: -1;
 }
 
 /* Navegación */


### PR DESCRIPTION
## Summary
- add background image to hero section with absolute positioning
- overlay gradient for better contrast and content positioning

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fadfcbba88333987153d144a32f8a