### PR TITLE
feat: add responsive navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,15 @@
   </head>
   <body>
     <nav>
-      <ul>
-        <li><a href="#musica">Música</a></li>
-        <li><a href="#poesia">Poesía</a></li>
-        <li><a href="#profesional">Estrategia</a></li>
-        <li><a href="#contacto">Contacto</a></li>
-      </ul>
+      <div class="menu-toggle">
+        <span class="menu-icon">☰</span>
+        <ul>
+          <li><a href="#musica">Música</a></li>
+          <li><a href="#poesia">Poesía</a></li>
+          <li><a href="#profesional">Estrategia</a></li>
+          <li><a href="#contacto">Contacto</a></li>
+        </ul>
+      </div>
     </nav>
 
     <div class="container">
@@ -201,6 +204,15 @@
             behavior: "smooth",
           });
         });
+      });
+    </script>
+
+    <!-- MENU TOGGLE -->
+    <script>
+      const menuIcon = document.querySelector(".menu-icon");
+      const menuToggle = document.querySelector(".menu-toggle");
+      menuIcon.addEventListener("click", () => {
+        menuToggle.classList.toggle("open");
       });
     </script>
   </body>

--- a/style.css
+++ b/style.css
@@ -53,6 +53,37 @@ nav a {
   font-weight: bold;
 }
 
+/* Menú responsive */
+.menu-toggle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.menu-icon {
+  display: none;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .menu-icon {
+    display: block;
+    padding: 0.5rem 1rem;
+  }
+
+  .menu-toggle ul {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .menu-toggle.open ul {
+    display: flex;
+  }
+}
+
 /* Contenido General */
 section {
   padding: 4rem 2rem;


### PR DESCRIPTION
## Summary
- wrap navigation list in a `.menu-toggle` container with a menu icon
- add JavaScript to toggle menu visibility when the icon is clicked
- style responsive menu with media queries for open and closed states

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fadf65fd88333849a5c24522426da