### PR TITLE
feat: add overlay pseudo-element

### DIFF
--- a/style.css
+++ b/style.css
@@ -19,6 +19,15 @@ body {
   animation: fondoOndas 20s ease infinite;
 }
 
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
 /* Hero */
 #hero {
   height: 100vh;


### PR DESCRIPTION
## Summary
- add `body::before` overlay to apply semi-transparent dark layer
- use mix-blend-mode to improve contrast with gradient background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fae01538083338bb45ac35ec5ff00