### PR TITLE
Add gallery cards for music and poetry sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,16 @@
           >
           </iframe>
         </div>
+        <div class="galeria">
+          <div class="tarjeta">
+            <img src="https://via.placeholder.com/150" alt="Portada Álbum 1" />
+            <p>Álbum 1</p>
+          </div>
+          <div class="tarjeta">
+            <img src="https://via.placeholder.com/150" alt="Portada Álbum 2" />
+            <p>Álbum 2</p>
+          </div>
+        </div>
       </section>
 
       <!-- POESÍA -->
@@ -65,6 +75,20 @@
           Proyecto literario íntimo donde cada palabra busca sanar, descubrir y
           trascender.
         </p>
+        <div class="galeria">
+          <div class="tarjeta">
+            <blockquote>
+              En el susurro del viento se esconde un verso,
+              <br />el secreto que el alma busca.
+            </blockquote>
+          </div>
+          <div class="tarjeta">
+            <blockquote>
+              Cada latido escribe un poema nuevo,
+              <br />hasta que el silencio rime.
+            </blockquote>
+          </div>
+        </div>
       </section>
 
       <!-- PROFESIONAL -->

--- a/style.css
+++ b/style.css
@@ -156,6 +156,38 @@ blockquote {
   margin: 0 auto;
 }
 
+/* Galería de tarjetas */
+.galeria {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.tarjeta {
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tarjeta img {
+  width: 100%;
+  display: block;
+}
+
+.tarjeta:hover {
+  transform: scale(1.02);
+  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.5);
+}
+
+.tarjeta p,
+.tarjeta blockquote {
+  margin: 0.5rem 1rem 1rem;
+  font-size: 0.9rem;
+}
+
 /* Profesional */
 #profesional {
   position: relative;


### PR DESCRIPTION
## Summary
- Add album and poem cards inside Música and Poesía sections
- Style new gallery and cards with grid layout, shadows, and hover effects

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fae03f2e483339db3229c7691dce7