### PR TITLE
Add Unsplash backgrounds for each site section

### DIFF
--- a/style.css
+++ b/style.css
@@ -65,6 +65,9 @@ body {
   opacity: 0;
   transform: translateY(20px);
   transition: opacity 0.6s ease, transform 0.6s ease;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .slide.active {
@@ -109,11 +112,22 @@ p {
   pointer-events: none;
 }
 
-/* Fondos en tonos pastel */
-#inicio { background: #f8d5d1; }
-#musica { background: #d0e8f2; }
-#poesia { background: #e4d1f8; }
-#profesional { background: #d2f8d3; }
+/* Fondos con imágenes de Unsplash */
+#inicio {
+  background: #f8d5d1 url('https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1200&q=80') center/cover no-repeat;
+}
+
+#musica {
+  background: #d0e8f2 url('https://images.unsplash.com/photo-1511379938547-c1f69419868d?auto=format&fit=crop&w=1200&q=80') center/cover no-repeat;
+}
+
+#poesia {
+  background: #e4d1f8 url('https://images.unsplash.com/photo-1509021436665-8f07dbf5bf1d?auto=format&fit=crop&w=1200&q=80') center/cover no-repeat;
+}
+
+#profesional {
+  background: #d2f8d3 url('https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80') center/cover no-repeat;
+}
 
 /* Indicador lateral */
 .slide-indicator {


### PR DESCRIPTION
## Summary
- Use Unsplash images as backgrounds for all sections
- Ensure slides cover and center background images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d88047008333833954baee2e9a3f