### PR TITLE
Customize particles by section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/main.js
+++ b/main.js
@@ -44,44 +44,61 @@ document.addEventListener('DOMContentLoaded', () => {
     if (e.key === 'ArrowLeft') updateSlide(currentSlide - 1);
   });
 
-  // Partículas simples
-  function initParticles(canvas, color) {
+  // Partículas personalizadas por sección
+  function initParticles(canvas, config) {
     const ctx = canvas.getContext('2d');
-    const particles = Array.from({ length: 30 }, () => ({
-      x: Math.random() * canvas.width,
-      y: Math.random() * canvas.height,
-      r: Math.random() * 3 + 1,
-      vx: (Math.random() - 0.5) * 0.5,
-      vy: (Math.random() - 0.5) * 0.5,
-    }));
+    const particles = [];
 
     function resize() {
-      canvas.width = canvas.offsetWidth;
-      canvas.height = canvas.offsetHeight;
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+      const count = Math.max(30, Math.floor((canvas.width * canvas.height) / 15000));
+      particles.length = 0;
+      for (let i = 0; i < count; i++) {
+        particles.push({
+          x: Math.random() * canvas.width,
+          y: Math.random() * canvas.height,
+          size: Math.random() * 24 + 12,
+          vx: (Math.random() - 0.5) * 0.5,
+          vy: (Math.random() - 0.5) * 0.5,
+          symbol: config.symbols[Math.floor(Math.random() * config.symbols.length)]
+        });
+      }
     }
+
     resize();
     window.addEventListener('resize', resize);
 
     function draw() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = color;
       particles.forEach(p => {
         p.x += p.vx;
         p.y += p.vy;
         if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
         if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
-        ctx.beginPath();
-        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-        ctx.fill();
+
+        ctx.save();
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.font = `${p.size}px sans-serif`;
+        if (config.color) ctx.fillStyle = config.color;
+        ctx.fillText(p.symbol, p.x, p.y);
+        ctx.restore();
       });
       requestAnimationFrame(draw);
     }
+
     draw();
   }
 
   document.querySelectorAll('.particle-canvas').forEach((canvas, idx) => {
-    const colors = ['rgba(255,255,255,0.4)', 'rgba(0,0,0,0.3)', 'rgba(255,255,255,0.4)', 'rgba(0,0,0,0.3)'];
-    initParticles(canvas, colors[idx]);
+    const configs = [
+      { symbols: ['★', '✦', '✧', '✩'], color: 'rgba(255,255,255,0.4)' },
+      { symbols: ['♪', '♫', '♩', '♬'], color: 'rgba(0,0,0,0.3)' },
+      { symbols: ['✒', '📝', '📖', '✍'], color: 'rgba(255,255,255,0.4)' },
+      { symbols: ['🤖', '💡', '📈', '📣'], color: 'rgba(0,0,0,0.3)' }
+    ];
+    initParticles(canvas, configs[idx] || configs[0]);
   });
 
   // Texto del poema con efecto de máquina de escribir

--- a/style.css
+++ b/style.css
@@ -104,8 +104,8 @@ p {
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- Show section-specific particle icons (notes, writing, AI/marketing symbols)
- Resize particle canvas to always cover the full viewport
- Ignore node_modules in version control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d8a42d548333b084a2d2bc83b67e